### PR TITLE
Nerf AR bonus and buff base speed for Relax mod

### DIFF
--- a/src/osu/difficulty/calculator.rs
+++ b/src/osu/difficulty/calculator.rs
@@ -65,9 +65,11 @@ impl OsuRatingCalculator<'_> {
             };
 
         let ar_factor = if self.approach_rate > 10.33 {
-            0.3 * (self.approach_rate - 10.33)
+            let factor = if self.mods.rx() { 0.2 } else { 0.3 };
+            factor * (self.approach_rate - 10.33)
         } else if self.approach_rate < 8.0 {
-            0.05 * (8.0 - self.approach_rate)
+            let factor = if self.mods.rx() { 0.04 } else { 0.05 };
+            factor * (8.0 - self.approach_rate)
         } else {
             0.0
         };
@@ -115,7 +117,8 @@ impl OsuRatingCalculator<'_> {
         let ar_factor = if self.mods.ap() {
             0.0
         } else if self.approach_rate > 10.33 {
-            0.3 * (self.approach_rate - 10.33)
+            let factor = if self.mods.rx() { 0.2 } else { 0.3 };
+            factor * (self.approach_rate - 10.33)
         } else {
             0.0
         };

--- a/src/osu/performance/calculator.rs
+++ b/src/osu/performance/calculator.rs
@@ -538,8 +538,8 @@ impl OsuPerformanceCalculator<'_> {
         if self.mods.rx() {
             // Relax completely removes tapping skill from the equation,
             // so speed-based PP should scale weaker than normal plays.
-            // The 0.83 base is (stolen from akatsuki's) arbitrary but gives a good scaling.
-            return 0.83 * accuracy_depression;
+            // The 0.88 base is (stolen from akatsuki's) arbitrary but gives a good scaling.
+            return 0.88 * accuracy_depression;
         }
 
         1.1


### PR DESCRIPTION
Nerf AR bonus and buff base speed for Relax mod

This change adjusts the difficulty and performance calculation for the Relax mod in osu!.
- In `src/osu/difficulty/calculator.rs`: Reduces the Approach Rate (AR) bonus factor for High AR (> 10.33) from 0.3 to 0.2, and Low AR (< 8.0) from 0.05 to 0.04 when Relax is active.
- In `src/osu/performance/calculator.rs`: Increases the base speed exponent for Relax plays from 0.83 to 0.88 to provide a general buff relative to No Mod maps.

These changes aim to balance Relax gameplay by nerfing extreme AR bonuses while buffing the overall performance scaling.

---
*PR created automatically by Jules for task [15025466674444061898](https://jules.google.com/task/15025466674444061898) started by @remeliah*